### PR TITLE
Filter out German and Italian Locations

### DIFF
--- a/src/Provider/Location.php
+++ b/src/Provider/Location.php
@@ -22,6 +22,10 @@ class Location extends Base
         $zipcodeSearch = new ZipcodeSearch();
         $zipcodeDataSet = $zipcodeSearch->getDataSet();
 
+        $zipcodeDataSet = array_filter($zipcodeDataSet, function ($zipcode) {
+            return ! in_array($zipcode['canton'], ['DE', 'IT']);
+        });
+
         $randomLocation = static::randomElement($zipcodeDataSet);
 
         $cantonManager = new CantonManager();


### PR DESCRIPTION
The zipcode dataset includes German and Italian locations, as their zipcodes are registered in Switzerland.
As we only want valid Swiss locations, let's filter out all datasets where the "canton" is "DE" or "IT".